### PR TITLE
Fix for panic if input is 0.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,9 @@ pub fn read_choice(
         }
         match ans.parse::<usize>() {
             Ok(a) => {
+                if a < 1 {
+                    println!("{} is not a valid option (too small)", a);
+                }
                 let ans = a - 1;
                 if ans < options.len() {
                     return Ok(ans);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,7 @@ pub fn read_choice(
             Ok(a) => {
                 if a < 1 {
                     println!("{} is not a valid option (too small)", a);
+                    continue;
                 }
                 let ans = a - 1;
                 if ans < options.len() {


### PR DESCRIPTION
Hello, 

I came across this lovely handy crate and wanted to contribute a fix I found for a undocumented panic.

If you run the following example `let choice = read_human::read_choice("What is your gender?", &["male", "female"], None)?;` and input 0 you will overflow the usize value and cause a panic. I propose to introduce a new error, _X is not a valid option (too small)_, to the user much like the value _X is not a valid option (too big)_ exists today.